### PR TITLE
app_preferenceを作成

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -272,7 +272,7 @@ This is a Flutter mobile application development project using Claude Code with 
 
 <!-- AUTO-GENERATED SECTION: This section is automatically updated when project structure changes -->
 
-```
+```bash
 flutter_template_project/
 ├── .claude-workspaces/         # Claude Code working directories (replaces worktrees/)
 ├── app/                        # Main Flutter application
@@ -348,11 +348,6 @@ mise run format       # Format all files (calls both above)
 
 # Build and run
 mise run run              # Run app (debug) (calls melos exec --scope=app -- flutter run)
-mise run run-release      # Run app (release) (calls melos exec --scope=app -- flutter run --release)
-mise run build            # Build all platforms (calls melos exec --scope=app -- flutter build)
-mise run build-android    # Build Android APK (calls melos exec --scope=app -- flutter build apk)
-mise run build-ios        # Build iOS (calls melos exec --scope=app -- flutter build ios)
-mise run build-web        # Build web (calls melos exec --scope=app -- flutter build web)
 
 # Maintenance
 mise run clean-branch     # Clean git branches/worktrees (calls ./scripts/clean-branch.sh)
@@ -507,15 +502,15 @@ For detailed GitHub Issue processing workflow, execution examples, and configura
 
 **Purpose**: Implement complete AI Review-First development cycle with Claude as "Senior Reviewer"
 
-**Core Cycle: 小さなドラフト → 厳しい批評 → 再生成 → リリース**
+**Core Cycle: Small draft → Critical review → Regenerate → Release**
 
 ```mermaid
 flowchart LR
-    A[最小実装] --> B[AIレビュー]
-    B --> C[改善実装]
-    C --> D{品質OK?}
+    A[Minimal Implementation] --> B[AI Review]
+    B --> C[Improved Implementation]
+    C --> D{Quality OK?}
     D -->|No| B
-    D -->|Yes| E[リリース]
+    D -->|Yes| E[Release]
 ```
 
 **Implementation Steps**:

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ AI支援開発とモダンアーキテクチャを組み合わせた、GitHub Is
 
 ### クイックスタート
 
-````bash
+```bash
 # 1. プロジェクトを取得
 git clone <repository-url>
 cd flutter_template_project
@@ -112,7 +112,7 @@ graph TB
     D --> E
     A --> I
     M --> N[Production Release]
-````
+```
 
 ### 技術スタック
 
@@ -149,7 +149,7 @@ flowchart TD
 
 ### GitHub Issues統合AI開発プロセス
 
-````mermaid
+```mermaid
 sequenceDiagram
     participant Dev as 開発者
     participant GitHub as GitHub Issues
@@ -202,7 +202,7 @@ sequenceDiagram
 # 🔄 Phase 5: 品質ゲート検証
 # 🔄 Phase 6: GitHub Actions CI/CD統合
 # ✅ Phase 7: 完了通知 + 人間最終検証
-````
+```
 
 ### Claude 4レビュー品質基準
 
@@ -371,11 +371,6 @@ mise run format       # 全ファイル整形 (両方の整形実行)
 
 # ビルドと実行
 mise run run              # アプリ実行（デバッグ） (melos exec --scope=app -- flutter run呼出)
-mise run run-release      # アプリ実行（リリース） (melos exec --scope=app -- flutter run --release呼出)
-mise run build            # 全プラットフォームビルド (melos exec --scope=app -- flutter build呼出)
-mise run build-android    # Android APKビルド (melos exec --scope=app -- flutter build apk呼出)
-mise run build-ios        # iOSビルド (melos exec --scope=app -- flutter build ios呼出)
-mise run build-web        # Webビルド (melos exec --scope=app -- flutter build web呼出)
 
 # メンテナンス
 mise run clean-branch     # Gitブランチ/ワークツリークリーン (./scripts/clean-branch.sh呼出)
@@ -403,7 +398,7 @@ bun run clean             # クリーンと再インストール
 
 ## プロジェクト構成
 
-```
+```bash
 flutter_template_project/
 ├── 📱 app/                      # メインアプリケーション
 │   ├── lib/                     # アプリケーションコード

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ export GITHUB_ACTIONS_CHECK=true
 
 # 5. コード生成を実行
 melos run gen
+```
 
 ## アーキテクチャ概要
 
@@ -178,6 +179,7 @@ sequenceDiagram
     Actions->>QA: 品質ゲート検証
     QA->>Dev: 🔔 完了通知
     Dev->>GitHub: Issue完了
+```
 
 ### /task コマンド: Claude 4 AI Review-First統合
 

--- a/docs/WORKTREE_ARCHITECTURE.md
+++ b/docs/WORKTREE_ARCHITECTURE.md
@@ -281,10 +281,7 @@ flutter_template_project/
 ```bash
 # 各GitHub Issueが完全に独立
 cd .claude-workspaces/issue-123  # GitHub Issue #123: 新機能開発
-mise run run                     # 統一されたコマンド実行
-
-cd ../issue-456                  # GitHub Issue #456: UI改善
-mise run run-release             # リリースビルドで実行
+mise run test                     # テスト実行
 
 cd ../issue-789                  # GitHub Issue #789: バグ修正
 mise run test                    # テスト実行

--- a/packages/app_preferences/test/src/providers/app_preferences_provider_test.dart
+++ b/packages/app_preferences/test/src/providers/app_preferences_provider_test.dart
@@ -1,0 +1,206 @@
+import 'package:app_preferences/src/providers/app_preferences_provider.dart';
+import 'package:app_preferences/src/repositories/app_preferences_repository.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  group('AppLocaleProvider', () {
+    late ProviderContainer container;
+    late AppPreferencesRepository repository;
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      final mockPrefs = await SharedPreferences.getInstance();
+      repository = AppPreferencesRepository(prefs: mockPrefs);
+
+      container = ProviderContainer(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(mockPrefs),
+          appPreferencesRepositoryProvider.overrideWithValue(repository),
+        ],
+      );
+    });
+
+    tearDown(() {
+      container.dispose();
+    });
+
+    test(
+      'build returns default Japanese locale when no preference is stored',
+      () async {
+        final provider = container.read(appLocaleProviderProvider.future);
+        final result = await provider;
+
+        expect(result.languageCode, 'ja');
+        expect(result.countryCode, isNull);
+      },
+    );
+
+    test('build returns stored locale preference', () async {
+      const locale = Locale('en', 'US');
+      await repository.setLocale(locale);
+
+      final provider = container.read(appLocaleProviderProvider.future);
+      final result = await provider;
+
+      expect(result.languageCode, 'en');
+      expect(result.countryCode, 'US');
+    });
+
+    test('setLocale updates the preference and state', () async {
+      const newLocale = Locale('fr', 'FR');
+      final notifier = container.read(appLocaleProviderProvider.notifier);
+
+      await notifier.setLocale(newLocale);
+
+      final result = await container.read(appLocaleProviderProvider.future);
+      expect(result.languageCode, 'fr');
+      expect(result.countryCode, 'FR');
+
+      // Verify it was stored in repository
+      final storedLocale = await repository.getLocale();
+      expect(storedLocale?.languageCode, 'fr');
+      expect(storedLocale?.countryCode, 'FR');
+    });
+
+    test('clearLocale removes preference and resets to default', () async {
+      // First set a locale
+      const locale = Locale('en', 'US');
+      await repository.setLocale(locale);
+
+      final notifier = container.read(appLocaleProviderProvider.notifier);
+      await notifier.clearLocale();
+
+      final result = await container.read(appLocaleProviderProvider.future);
+      expect(result.languageCode, 'ja'); // Should reset to default
+      expect(result.countryCode, isNull);
+
+      // Verify it was cleared from repository
+      final storedLocale = await repository.getLocale();
+      expect(storedLocale, isNull);
+    });
+  });
+
+  group('AppThemeProvider', () {
+    late ProviderContainer container;
+    late AppPreferencesRepository repository;
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      final mockPrefs = await SharedPreferences.getInstance();
+      repository = AppPreferencesRepository(prefs: mockPrefs);
+
+      container = ProviderContainer(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(mockPrefs),
+          appPreferencesRepositoryProvider.overrideWithValue(repository),
+        ],
+      );
+    });
+
+    tearDown(() {
+      container.dispose();
+    });
+
+    test(
+      'build returns system theme mode when no preference is stored',
+      () async {
+        final provider = container.read(appThemeProviderProvider.future);
+        final result = await provider;
+
+        expect(result, ThemeMode.system);
+      },
+    );
+
+    test('build returns stored theme mode preference', () async {
+      await repository.setTheme(ThemeMode.dark);
+
+      final provider = container.read(appThemeProviderProvider.future);
+      final result = await provider;
+
+      expect(result, ThemeMode.dark);
+    });
+
+    test('setThemeMode updates the preference and state', () async {
+      const newThemeMode = ThemeMode.light;
+      final notifier = container.read(appThemeProviderProvider.notifier);
+
+      await notifier.setThemeMode(newThemeMode);
+
+      final result = await container.read(appThemeProviderProvider.future);
+      expect(result, ThemeMode.light);
+
+      // Verify it was stored in repository
+      final storedTheme = await repository.getTheme();
+      expect(storedTheme, ThemeMode.light);
+    });
+
+    test('clearTheme removes preference and resets to default', () async {
+      // First set a theme
+      await repository.setTheme(ThemeMode.dark);
+
+      final notifier = container.read(appThemeProviderProvider.notifier);
+      await notifier.clearTheme();
+
+      final result = await container.read(appThemeProviderProvider.future);
+      expect(result, ThemeMode.system); // Should reset to default
+
+      // Verify it was cleared from repository
+      final storedTheme = await repository.getTheme();
+      expect(storedTheme, isNull);
+    });
+
+    test('supports all theme modes', () async {
+      final notifier = container.read(appThemeProviderProvider.notifier);
+
+      // Test system mode
+      await notifier.setThemeMode(ThemeMode.system);
+      var result = await container.read(appThemeProviderProvider.future);
+      expect(result, ThemeMode.system);
+
+      // Test light mode
+      await notifier.setThemeMode(ThemeMode.light);
+      result = await container.read(appThemeProviderProvider.future);
+      expect(result, ThemeMode.light);
+
+      // Test dark mode
+      await notifier.setThemeMode(ThemeMode.dark);
+      result = await container.read(appThemeProviderProvider.future);
+      expect(result, ThemeMode.dark);
+    });
+  });
+
+  group('Provider Dependencies', () {
+    test(
+      'appPreferencesRepositoryProvider creates repository with SharedPreferences',
+      () async {
+        SharedPreferences.setMockInitialValues({});
+        final mockPrefs = await SharedPreferences.getInstance();
+
+        final container = ProviderContainer(
+          overrides: [
+            sharedPreferencesProvider.overrideWithValue(mockPrefs),
+          ],
+        );
+
+        final repository = container.read(appPreferencesRepositoryProvider);
+        expect(repository, isA<AppPreferencesRepository>());
+
+        container.dispose();
+      },
+    );
+
+    test('sharedPreferencesProvider throws UnimplementedError by default', () {
+      final container = ProviderContainer();
+
+      expect(
+        () => container.read(sharedPreferencesProvider),
+        throwsA(isA<UnimplementedError>()),
+      );
+
+      container.dispose();
+    });
+  });
+}

--- a/packages/app_preferences/test/src/repositories/app_preferences_repository_test.dart
+++ b/packages/app_preferences/test/src/repositories/app_preferences_repository_test.dart
@@ -1,0 +1,213 @@
+import 'dart:convert';
+
+import 'package:app_preferences/src/repositories/app_preferences_repository.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  group('AppPreferencesRepository', () {
+    late AppPreferencesRepository repository;
+    late SharedPreferences mockPrefs;
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      mockPrefs = await SharedPreferences.getInstance();
+      repository = AppPreferencesRepository(prefs: mockPrefs);
+    });
+
+    group('Locale Management', () {
+      test('getLocale returns null when no preference is stored', () async {
+        final result = await repository.getLocale();
+        expect(result, isNull);
+      });
+
+      test('setLocale stores locale preference correctly', () async {
+        const locale = Locale('en', 'US');
+
+        await repository.setLocale(locale);
+
+        final storedJson = mockPrefs.getString('app_locale');
+        expect(storedJson, isNotNull);
+
+        final decoded = jsonDecode(storedJson!) as Map<String, dynamic>;
+        expect(decoded['languageCode'], 'en');
+        expect(decoded['countryCode'], 'US');
+      });
+
+      test('getLocale retrieves stored locale preference', () async {
+        const locale = Locale('ja', 'JP');
+        await repository.setLocale(locale);
+
+        final result = await repository.getLocale();
+
+        expect(result?.languageCode, 'ja');
+        expect(result?.countryCode, 'JP');
+      });
+
+      test('getLocale handles locale without country code', () async {
+        const locale = Locale('ja');
+        await repository.setLocale(locale);
+
+        final result = await repository.getLocale();
+
+        expect(result?.languageCode, 'ja');
+        expect(result?.countryCode, isNull);
+      });
+
+      test('getLocale returns null when invalid JSON is stored', () async {
+        await mockPrefs.setString('app_locale', 'invalid json');
+
+        final result = await repository.getLocale();
+
+        expect(result, isNull);
+      });
+
+      test('clearLocale removes stored preference', () async {
+        const locale = Locale('en');
+        await repository.setLocale(locale);
+
+        await repository.clearLocale();
+
+        final result = await repository.getLocale();
+        expect(result, isNull);
+      });
+    });
+
+    group('Theme Management', () {
+      test('getTheme returns null when no preference is stored', () async {
+        final result = await repository.getTheme();
+        expect(result, isNull);
+      });
+
+      test('setTheme stores system theme preference correctly', () async {
+        await repository.setTheme(ThemeMode.system);
+
+        final stored = mockPrefs.getString('app_theme');
+        expect(stored, 'system');
+      });
+
+      test('setTheme stores light theme preference correctly', () async {
+        await repository.setTheme(ThemeMode.light);
+
+        final stored = mockPrefs.getString('app_theme');
+        expect(stored, 'light');
+      });
+
+      test('setTheme stores dark theme preference correctly', () async {
+        await repository.setTheme(ThemeMode.dark);
+
+        final stored = mockPrefs.getString('app_theme');
+        expect(stored, 'dark');
+      });
+
+      test('getTheme retrieves system theme preference', () async {
+        await repository.setTheme(ThemeMode.system);
+
+        final result = await repository.getTheme();
+
+        expect(result, ThemeMode.system);
+      });
+
+      test('getTheme retrieves light theme preference', () async {
+        await repository.setTheme(ThemeMode.light);
+
+        final result = await repository.getTheme();
+
+        expect(result, ThemeMode.light);
+      });
+
+      test('getTheme retrieves dark theme preference', () async {
+        await repository.setTheme(ThemeMode.dark);
+
+        final result = await repository.getTheme();
+
+        expect(result, ThemeMode.dark);
+      });
+
+      test('getTheme returns null for invalid theme string', () async {
+        await mockPrefs.setString('app_theme', 'invalid_theme');
+
+        final result = await repository.getTheme();
+
+        expect(result, isNull);
+      });
+
+      test('clearTheme removes stored preference', () async {
+        await repository.setTheme(ThemeMode.dark);
+
+        await repository.clearTheme();
+
+        final result = await repository.getTheme();
+        expect(result, isNull);
+      });
+    });
+
+    group('Initialization', () {
+      test(
+        'initializeLocale calls onLocaleFound when preference exists',
+        () async {
+          const locale = Locale('en', 'US');
+          await repository.setLocale(locale);
+
+          String? receivedLanguageCode;
+          var deviceLocaleUsed = false;
+
+          await repository.initializeLocale(
+            onLocaleFound: (languageCode) async {
+              receivedLanguageCode = languageCode;
+            },
+            onUseDeviceLocale: () async {
+              deviceLocaleUsed = true;
+            },
+          );
+
+          expect(receivedLanguageCode, 'en');
+          expect(deviceLocaleUsed, false);
+        },
+      );
+
+      test(
+        'initializeLocale calls onUseDeviceLocale when no preference exists',
+        () async {
+          String? receivedLanguageCode;
+          var deviceLocaleUsed = false;
+
+          await repository.initializeLocale(
+            onLocaleFound: (languageCode) async {
+              receivedLanguageCode = languageCode;
+            },
+            onUseDeviceLocale: () async {
+              deviceLocaleUsed = true;
+            },
+          );
+
+          expect(receivedLanguageCode, isNull);
+          expect(deviceLocaleUsed, true);
+        },
+      );
+
+      test(
+        'initializeLocale calls onUseDeviceLocale when invalid JSON is stored',
+        () async {
+          await mockPrefs.setString('app_locale', 'invalid json');
+
+          String? receivedLanguageCode;
+          var deviceLocaleUsed = false;
+
+          await repository.initializeLocale(
+            onLocaleFound: (languageCode) async {
+              receivedLanguageCode = languageCode;
+            },
+            onUseDeviceLocale: () async {
+              deviceLocaleUsed = true;
+            },
+          );
+
+          expect(receivedLanguageCode, isNull);
+          expect(deviceLocaleUsed, true);
+        },
+      );
+    });
+  });
+}

--- a/packages/app_preferences/test/src/widgets/dialogs/locale_selection_dialog_test.dart
+++ b/packages/app_preferences/test/src/widgets/dialogs/locale_selection_dialog_test.dart
@@ -1,0 +1,161 @@
+import 'package:app_preferences/src/providers/app_preferences_provider.dart';
+import 'package:app_preferences/src/repositories/app_preferences_repository.dart';
+import 'package:app_preferences/src/widgets/dialogs/locale_selection_dialog.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  group('LocaleOption', () {
+    test('creates with required properties', () {
+      const option = LocaleOption(
+        languageCode: 'en',
+        displayName: 'English',
+      );
+
+      expect(option.languageCode, 'en');
+      expect(option.displayName, 'English');
+    });
+  });
+
+  group('LocaleSelectionDialog', () {
+    late List<LocaleOption> testLocales;
+    late AppPreferencesRepository repository;
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      final mockPrefs = await SharedPreferences.getInstance();
+      repository = AppPreferencesRepository(prefs: mockPrefs);
+
+      testLocales = const [
+        LocaleOption(languageCode: 'en', displayName: 'English'),
+        LocaleOption(languageCode: 'ja', displayName: '日本語'),
+        LocaleOption(languageCode: 'es', displayName: 'Español'),
+      ];
+    });
+
+    Future<Widget> createTestWidget({
+      Future<void> Function(String)? onLocaleChanged,
+      Widget? icon,
+    }) async {
+      final mockPrefs = await SharedPreferences.getInstance();
+      return ProviderScope(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(mockPrefs),
+          appPreferencesRepositoryProvider.overrideWithValue(repository),
+        ],
+        child: MaterialApp(
+          home: Builder(
+            builder: (context) => Scaffold(
+              body: ElevatedButton(
+                onPressed: () {
+                  showDialog<void>(
+                    context: context,
+                    builder: (context) => LocaleSelectionDialog(
+                      title: 'Select Language',
+                      availableLocales: testLocales,
+                      cancelLabel: 'Cancel',
+                      onLocaleChanged: onLocaleChanged,
+                      icon: icon,
+                    ),
+                  );
+                },
+                child: const Text('Show Dialog'),
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    testWidgets('displays title and cancel button', (tester) async {
+      await tester.pumpWidget(await createTestWidget());
+      await tester.tap(find.text('Show Dialog'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Select Language'), findsOneWidget);
+      expect(find.text('Cancel'), findsOneWidget);
+    });
+
+    testWidgets('displays all available locale options', (tester) async {
+      await tester.pumpWidget(await createTestWidget());
+      await tester.tap(find.text('Show Dialog'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('English'), findsOneWidget);
+      expect(find.text('日本語'), findsOneWidget);
+      expect(find.text('Español'), findsOneWidget);
+    });
+
+    testWidgets('displays icon when provided', (tester) async {
+      const icon = Icon(Icons.language, key: Key('test_icon'));
+      await tester.pumpWidget(await createTestWidget(icon: icon));
+      await tester.tap(find.text('Show Dialog'));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('test_icon')), findsOneWidget);
+    });
+
+    testWidgets('updates locale when option is selected', (tester) async {
+      await tester.pumpWidget(await createTestWidget());
+      await tester.tap(find.text('Show Dialog'));
+      await tester.pumpAndSettle();
+
+      // Tap on Spanish option (this automatically closes dialog)
+      await tester.tap(find.text('Español'));
+      await tester.pumpAndSettle();
+
+      // Dialog should be closed now
+      expect(find.text('Select Language'), findsNothing);
+
+      // Verify locale was updated
+      final storedLocale = await repository.getLocale();
+      expect(storedLocale?.languageCode, 'es');
+    });
+
+    testWidgets('calls onLocaleChanged callback when provided', (tester) async {
+      String? changedLanguageCode;
+
+      await tester.pumpWidget(
+        await createTestWidget(
+          onLocaleChanged: (languageCode) async {
+            changedLanguageCode = languageCode;
+          },
+        ),
+      );
+      await tester.tap(find.text('Show Dialog'));
+      await tester.pumpAndSettle();
+
+      // Tap on Japanese option (this automatically closes dialog)
+      await tester.tap(find.text('日本語'));
+      await tester.pumpAndSettle();
+
+      // Dialog should be closed now
+      expect(find.text('Select Language'), findsNothing);
+
+      // Verify callback was called
+      expect(changedLanguageCode, 'ja');
+    });
+
+    testWidgets('does not update locale when cancelled', (tester) async {
+      // Set initial locale
+      await repository.setLocale(const Locale('en'));
+
+      await tester.pumpWidget(await createTestWidget());
+      await tester.tap(find.text('Show Dialog'));
+      await tester.pumpAndSettle();
+
+      // Tap Cancel button
+      await tester.tap(find.text('Cancel'));
+      await tester.pumpAndSettle();
+
+      // Dialog should be closed
+      expect(find.text('Select Language'), findsNothing);
+
+      // Verify locale was not changed
+      final storedLocale = await repository.getLocale();
+      expect(storedLocale?.languageCode, 'en');
+    });
+  });
+}

--- a/packages/app_preferences/test/src/widgets/dialogs/theme_selection_dialog_test.dart
+++ b/packages/app_preferences/test/src/widgets/dialogs/theme_selection_dialog_test.dart
@@ -1,0 +1,153 @@
+import 'package:app_preferences/src/providers/app_preferences_provider.dart';
+import 'package:app_preferences/src/repositories/app_preferences_repository.dart';
+import 'package:app_preferences/src/widgets/dialogs/theme_selection_dialog.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  group('ThemeSelectionDialog', () {
+    late AppPreferencesRepository repository;
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      final mockPrefs = await SharedPreferences.getInstance();
+      repository = AppPreferencesRepository(prefs: mockPrefs);
+    });
+
+    Future<Widget> createTestWidget({Widget? icon}) async {
+      final mockPrefs = await SharedPreferences.getInstance();
+      return ProviderScope(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(mockPrefs),
+          appPreferencesRepositoryProvider.overrideWithValue(repository),
+        ],
+        child: MaterialApp(
+          home: Builder(
+            builder: (context) => Scaffold(
+              body: ElevatedButton(
+                onPressed: () {
+                  showDialog<void>(
+                    context: context,
+                    builder: (context) => ThemeSelectionDialog(
+                      title: 'Select Theme',
+                      systemLabel: 'System',
+                      lightLabel: 'Light',
+                      darkLabel: 'Dark',
+                      cancelLabel: 'Cancel',
+                      icon: icon,
+                    ),
+                  );
+                },
+                child: const Text('Show Dialog'),
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    testWidgets('displays title and cancel button', (tester) async {
+      await tester.pumpWidget(await createTestWidget());
+      await tester.tap(find.text('Show Dialog'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Select Theme'), findsOneWidget);
+      expect(find.text('Cancel'), findsOneWidget);
+    });
+
+    testWidgets('displays all theme mode options', (tester) async {
+      await tester.pumpWidget(await createTestWidget());
+      await tester.tap(find.text('Show Dialog'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('System'), findsOneWidget);
+      expect(find.text('Light'), findsOneWidget);
+      expect(find.text('Dark'), findsOneWidget);
+    });
+
+    testWidgets('displays icon when provided', (tester) async {
+      const icon = Icon(Icons.palette, key: Key('test_icon'));
+      await tester.pumpWidget(await createTestWidget(icon: icon));
+      await tester.tap(find.text('Show Dialog'));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('test_icon')), findsOneWidget);
+    });
+
+    testWidgets('updates theme when system option is selected', (tester) async {
+      // Set initial theme to light
+      await repository.setTheme(ThemeMode.light);
+
+      await tester.pumpWidget(await createTestWidget());
+      await tester.tap(find.text('Show Dialog'));
+      await tester.pumpAndSettle();
+
+      // Tap on System option (this automatically closes dialog)
+      await tester.tap(find.text('System'));
+      await tester.pumpAndSettle();
+
+      // Dialog should be closed now
+      expect(find.text('Select Theme'), findsNothing);
+
+      // Verify theme was updated
+      final storedTheme = await repository.getTheme();
+      expect(storedTheme, ThemeMode.system);
+    });
+
+    testWidgets('updates theme when light option is selected', (tester) async {
+      await tester.pumpWidget(await createTestWidget());
+      await tester.tap(find.text('Show Dialog'));
+      await tester.pumpAndSettle();
+
+      // Tap on Light option (this automatically closes dialog)
+      await tester.tap(find.text('Light'));
+      await tester.pumpAndSettle();
+
+      // Dialog should be closed now
+      expect(find.text('Select Theme'), findsNothing);
+
+      // Verify theme was updated
+      final storedTheme = await repository.getTheme();
+      expect(storedTheme, ThemeMode.light);
+    });
+
+    testWidgets('updates theme when dark option is selected', (tester) async {
+      await tester.pumpWidget(await createTestWidget());
+      await tester.tap(find.text('Show Dialog'));
+      await tester.pumpAndSettle();
+
+      // Tap on Dark option (this automatically closes dialog)
+      await tester.tap(find.text('Dark'));
+      await tester.pumpAndSettle();
+
+      // Dialog should be closed now
+      expect(find.text('Select Theme'), findsNothing);
+
+      // Verify theme was updated
+      final storedTheme = await repository.getTheme();
+      expect(storedTheme, ThemeMode.dark);
+    });
+
+    testWidgets('does not update theme when cancelled', (tester) async {
+      // Set initial theme
+      await repository.setTheme(ThemeMode.light);
+
+      await tester.pumpWidget(await createTestWidget());
+      await tester.tap(find.text('Show Dialog'));
+      await tester.pumpAndSettle();
+
+      // Tap Cancel button
+      await tester.tap(find.text('Cancel'));
+      await tester.pumpAndSettle();
+
+      // Dialog should be closed
+      expect(find.text('Select Theme'), findsNothing);
+
+      // Verify theme was not changed
+      final storedTheme = await repository.getTheme();
+      expect(storedTheme, ThemeMode.light);
+    });
+  });
+}


### PR DESCRIPTION
This pull request focuses on two major areas: improving documentation for project structure and workflows, and adding comprehensive unit tests for app preferences functionality. The documentation updates clarify project organization and workflows, while the tests enhance the reliability of locale and theme management in the app.

### Documentation Updates:
* Updated project structure descriptions in `CLAUDE.md` and `README.md` to use consistent formatting (`bash`) and translated Japanese text to English for better accessibility. [[1]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L275-R275) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L62-R62) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L404-R401)
* Removed outdated build commands from `CLAUDE.md` and `README.md`, streamlining the build instructions. [[1]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L351-L355) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L372-L376)
* Improved diagrams in `README.md` by translating labels and ensuring proper formatting for mermaid syntax. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L114-R115) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L151-R152)

### Unit Tests for App Preferences:
* Added unit tests in `packages/app_preferences/test/src/providers/app_preferences_provider_test.dart` to verify locale and theme management, including default values, updates, and clearing preferences.
* Added unit tests in `packages/app_preferences/test/src/repositories/app_preferences_repository_test.dart` to validate repository methods for storing, retrieving, and clearing locale and theme preferences, as well as initialization logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * コードブロックの言語指定やマークダウン構文の修正により、README.mdおよびCLAUDE.mdの可読性と整合性を向上。
  * 日本語で記載されていた開発サイクル説明やフローチャートを英語に統一。
  * 不要または非推奨のビルド・実行コマンド例を削除し、コマンド例の表記を整理。
  * ワークスペース運用例のコマンドをテスト実行に統一。

* **テスト**
  * アプリのロケール・テーマ設定プロバイダーのユニットテストを新規追加。
  * AppPreferencesRepositoryのロケール・テーマ管理機能のテストを追加。
  * ロケール選択ダイアログおよびテーマ選択ダイアログのウィジェットテストを追加し、UI表示やユーザー操作・状態遷移を検証。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->