### PR TITLE
fix: enforce lint failures for analyze commands

### DIFF
--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -9,7 +9,6 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  print('main');
 
   // Initialize locale from stored preferences or use device locale as fallback
   final sharedPrefs = await prefs.AppPreferencesInitializer.initializeLocale(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,7 +38,7 @@ melos:
     # Analyze all packages
     analyze:
       description: Analyze all packages
-      run: melos exec -- "dart analyze"
+      run: melos exec -- "dart analyze --fatal-infos"
 
     # Check slang translations
     analyze:slang:


### PR DESCRIPTION
## Summary
- analyzeコマンドでlintエラーやinfo警告があった場合に確実にコマンドが失敗するよう修正
- `dart analyze --fatal-infos`フラグを追加してinfoレベルの問題もエラーとして扱う
- main.dartからデバッグ用のprint文を削除

## Test plan
- [x] `mise run analyze`がlint問題なしで成功することを確認
- [x] lint問題がある場合にコマンドが失敗することを確認
- [x] CI/CDパイプラインでコード品質が保証されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * デバッグ用の出力を削除しました。
  * コード解析スクリプトに `--fatal-infos` オプションを追加し、情報レベルのメッセージもエラーとして扱うようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->